### PR TITLE
Configurable Credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-otp_releases:
+otp_release:
  - 19.2
  - 20.1
 elixir:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: elixir
+otp_releases:
+ - 19.2
+ - 20.1
+elixir:
+ - 1.5.2
+ - 1.4.5

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,29 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :atrium, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:atrium, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :atrium, api_key: "TEST_API_KEY",
+                client_id: "TEST_CLIENT_ID",
+                environment: "http://localhost:5000"

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,4 @@ use Mix.Config
 
 config :atrium, api_key: "TEST_API_KEY",
                 client_id: "TEST_CLIENT_ID",
-                environment: "http://localhost:5000"
+                base_url: "http://localhost:5000"

--- a/lib/atrium.ex
+++ b/lib/atrium.ex
@@ -1,10 +1,9 @@
 defmodule Atrium do
-  @mxAPIKEY "YOUR_MX_API_KEY"
-  @mxCLIENTID "YOUR_MX_CLIENT_ID"
-  @environment "https://vestibule.mx.com"
+  def api_key, do: Application.get_env(:atrium, :api_key, "")
 
-  # USER
+  def client_id, do: Application.get_env(:atrium, :client_id, "")
 
+  def environment, do: Application.get_env(:atrium, :environment, "https://vestibule.mx.com")
 
   # Required Parameters: None
   # Optional Parameters: identifier, is_disabled, metadata
@@ -346,8 +345,8 @@ defmodule Atrium do
   # Optional Parameters: None
   defp makeRequest(mode, endpoint, body) do
     Application.get_env(:atrium_ex, :api_key)
-    url = @environment <> endpoint
-    headers = [{ "Accept", "application/vnd.mx.atrium.v1<>json"}, {"Content-Type", "application/json"}, {"MX-API-Key", @mxAPIKEY }, {"MX-Client-ID", @mxCLIENTID }]
+    url = environment() <> endpoint
+    headers = [{ "Accept", "application/vnd.mx.atrium.v1<>json"}, {"Content-Type", "application/json"}, {"MX-API-Key", api_key() }, {"MX-Client-ID", client_id() }]
 
     if (mode == "GET") do
       case HTTPoison.get(url, headers, [timeout: 50_000, recv_timeout: 50_000]) do

--- a/lib/atrium.ex
+++ b/lib/atrium.ex
@@ -3,7 +3,7 @@ defmodule Atrium do
 
   def client_id, do: Application.get_env(:atrium, :client_id, "")
 
-  def environment, do: Application.get_env(:atrium, :environment, "https://vestibule.mx.com")
+  def base_url, do: Application.get_env(:atrium, :base_url, "https://vestibule.mx.com")
 
   # Required Parameters: None
   # Optional Parameters: identifier, is_disabled, metadata
@@ -345,7 +345,7 @@ defmodule Atrium do
   # Optional Parameters: None
   defp makeRequest(mode, endpoint, body) do
     Application.get_env(:atrium_ex, :api_key)
-    url = environment() <> endpoint
+    url = base_url() <> endpoint
     headers = [{ "Accept", "application/vnd.mx.atrium.v1<>json"}, {"Content-Type", "application/json"}, {"MX-API-Key", api_key() }, {"MX-Client-ID", client_id() }]
 
     if (mode == "GET") do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Atrium.Mixfile do
     [
       app: :atrium,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.4",
       start_permanent: Mix.env == :prod,
       deps: deps()
     ]

--- a/test/atrium_test.exs
+++ b/test/atrium_test.exs
@@ -3,8 +3,8 @@ defmodule AtriumTest do
   doctest Atrium
 
   test "provides an environment, api_key and client_id" do
-    assert is_binary(Atrium.environment())
-    assert is_binary(Atrium.api_key())
-    assert is_binary(Atrium.client_id())
+    assert Atrium.environment() == "http://localhost:5000"
+    assert Atrium.api_key() == "TEST_API_KEY"
+    assert Atrium.client_id() == "TEST_CLIENT_ID"
   end
 end

--- a/test/atrium_test.exs
+++ b/test/atrium_test.exs
@@ -3,7 +3,7 @@ defmodule AtriumTest do
   doctest Atrium
 
   test "provides an environment, api_key and client_id" do
-    assert Atrium.environment() == "http://localhost:5000"
+    assert Atrium.base_url() == "http://localhost:5000"
     assert Atrium.api_key() == "TEST_API_KEY"
     assert Atrium.client_id() == "TEST_CLIENT_ID"
   end

--- a/test/atrium_test.exs
+++ b/test/atrium_test.exs
@@ -2,7 +2,9 @@ defmodule AtriumTest do
   use ExUnit.Case
   doctest Atrium
 
-  test "greets the world" do
-    assert Atrium.hello() == :world
+  test "provides an environment, api_key and client_id" do
+    assert is_binary(Atrium.environment())
+    assert is_binary(Atrium.api_key())
+    assert is_binary(Atrium.client_id())
   end
 end


### PR DESCRIPTION
When we create a module attribute like `@mxAPIKEY` it gets compiled into the module. This means people can't set their own credentials unless they modify the source files themselves. This PR makes it so that in their own project they can just include some configuration like:

```elixir config/dev.exs
config :atrium, client_id: "YOUR_CLIENT_ID",
                api_key: "YOUR_API_KEY"
```

I also went ahead and setup a really basic unit test and configured TravisCI so it will run the unit tests for a couple of recent elixir versions to make sure this will work for people using the library.

/cc @brettmortensen @film42 